### PR TITLE
Allow controls to specify default properties/layout-info

### DIFF
--- a/src/components/design/design-app.e.tsx
+++ b/src/components/design/design-app.e.tsx
@@ -231,7 +231,7 @@ export class DesignApp extends CustomHtmlJsxElement {
           <h1>Web App Builder</h1>
           {/* Render each control as a button that inserts it */}
           {Array.from(this.descriptors.getDescriptors()).map((d) => (
-            <button onClick={() => this.addControl(d)}>Add {d.id}</button>
+            <button onClick={() => this.addControl(d)}>Add {d.displayName}</button>
           ))}
           <button onClick={() => this.deleteCurrent()}>Delete</button>
           <button onClick={() => this.doUndo()}>Undo</button>

--- a/src/components/design/design-surface.e.tsx
+++ b/src/components/design/design-surface.e.tsx
@@ -18,6 +18,7 @@ import {
   IControlDescriptor,
   tryGetValue,
   addValue,
+  IDefaultControlValues,
 } from 'src/controls/@commonControls';
 import { TextContentProperty } from '../../controls/properties/~TextProperties';
 
@@ -161,26 +162,21 @@ export class DesignSurfaceElement extends CustomHtmlElement {
     selectedControlChanged.trigger(this, this.getActiveControlContainer());
   }
 
-  public addNewControl(
-    descriptor: IControlDescriptor,
-    layout: IStoredPositionInfo = null,
-    properties: ISerializedPropertyBag = null,
-  ) {
-    let control = descriptor.createInstance();
+  public addNewControl(descriptor: IControlDescriptor, defaultValues?: IDefaultControlValues) {
+    let normalizedDefaults = this.createInitialValues(descriptor, defaultValues);
 
     // TODO copy the data
     let data: IControlSerializedData = {
-      position: layout ?? this.getDefaultLayoutInfo(descriptor),
       id: generateGuid(),
-      properties: properties ?? {},
       typeId: descriptor.id,
+      position: normalizedDefaults.position,
+      properties: normalizedDefaults.properties,
     };
 
-    this.addDefaultTextIfNeeded(descriptor, data.properties);
-
-    control.deserialize(data);
-
     snapLayout(data.position, this.gridSnap);
+
+    let control = descriptor.createInstance();
+    control.deserialize(data);
 
     addControlsUndoHandler.trigger(this, {
       entries: [
@@ -192,15 +188,34 @@ export class DesignSurfaceElement extends CustomHtmlElement {
     });
   }
 
-  private addDefaultTextIfNeeded(descriptor: IControlDescriptor, propertyBag: ISerializedPropertyBag) {
-    let textProperty = descriptor.getProperty<string>(TextContentProperty.id);
+  /**
+   * Creates the initial values to use when creating a control.
+   */
+  private createInitialValues(
+    descriptor: IControlDescriptor,
+    providedDefaults?: IDefaultControlValues,
+  ): Required<IDefaultControlValues> {
+    let descriptorProvidedDefaults = descriptor.getDefaultValues();
 
-    if (textProperty != null) {
-      let existingValue = tryGetValue(propertyBag, textProperty);
-      if (existingValue == undefined) {
-        addValue(propertyBag, textProperty, `${descriptor.id} text`);
-      }
-    }
+    // we prefer caller provided defaults over descriptor provided defaults
+    let position = providedDefaults?.position ?? descriptorProvidedDefaults.position;
+    let properties = providedDefaults?.properties ?? descriptorProvidedDefaults.properties;
+
+    // make sure we have some default position info for controls
+    position = Object.assign(
+      {
+        left: 20,
+        top: 20,
+        width: 40,
+        height: 60,
+      },
+      position,
+    );
+
+    return {
+      position,
+      properties,
+    };
   }
 
   /**
@@ -215,22 +230,6 @@ export class DesignSurfaceElement extends CustomHtmlElement {
     this._childControls.set(control.id, control);
 
     return controlContainer;
-  }
-
-  /**
-   * Gets the default layout information for the given control
-   */
-  private getDefaultLayoutInfo(descriptor: IControlDescriptor): IStoredPositionInfo {
-    if (descriptor == null) {
-      throw new Error('Null Descriptor');
-    }
-
-    return {
-      left: 20,
-      top: 20,
-      width: 40,
-      height: 60,
-    };
   }
 
   /**

--- a/src/components/design/design-surface.e.tsx
+++ b/src/components/design/design-surface.e.tsx
@@ -16,7 +16,10 @@ import {
   RootControl,
   rootControlDescriptor,
   IControlDescriptor,
+  tryGetValue,
+  addValue,
 } from 'src/controls/@commonControls';
+import { TextContentProperty } from '../../controls/properties/~TextProperties';
 
 export let selectedControlChanged = new RoutedEventDescriptor<ControlContainer>({
   id: 'selectedControlChanged',
@@ -173,7 +176,10 @@ export class DesignSurfaceElement extends CustomHtmlElement {
       typeId: descriptor.id,
     };
 
+    this.addDefaultTextIfNeeded(descriptor, data.properties);
+
     control.deserialize(data);
+
     snapLayout(data.position, this.gridSnap);
 
     addControlsUndoHandler.trigger(this, {
@@ -184,6 +190,17 @@ export class DesignSurfaceElement extends CustomHtmlElement {
         },
       ],
     });
+  }
+
+  private addDefaultTextIfNeeded(descriptor: IControlDescriptor, propertyBag: ISerializedPropertyBag) {
+    let textProperty = descriptor.getProperty<string>(TextContentProperty.id);
+
+    if (textProperty != null) {
+      let existingValue = tryGetValue(propertyBag, textProperty);
+      if (existingValue == undefined) {
+        addValue(propertyBag, textProperty, `${descriptor.id} text`);
+      }
+    }
   }
 
   /**

--- a/src/controls/Control.tsx
+++ b/src/controls/Control.tsx
@@ -1,6 +1,7 @@
 import { IControlDescriptor } from './controlRegistry';
 import { IStoredPositionInfo } from 'src/framework/layout';
 import { UniqueId } from 'src/framework/util';
+import { IControlProperty } from './controlProperties';
 
 export * from './controlProperties';
 
@@ -21,6 +22,16 @@ export interface IControlSerializedData {
   position: IStoredPositionInfo;
   properties: ISerializedPropertyBag;
   typeId: string;
+}
+
+/** Add the given property value to the property bag, overriding the existing value if it exists */
+export function addValue<T>(propertyBag: ISerializedPropertyBag, property: IControlProperty<T>, value: T) {
+  propertyBag[property.id] = value;
+}
+
+/** Retrieves the current property value from the property bag, returning undefined if it doesn't exist */
+export function tryGetValue<T>(propertyBag: ISerializedPropertyBag, property: IControlProperty<T>): T | undefined {
+  return propertyBag[property.id];
 }
 
 /** Base class for all controls that can be created */
@@ -80,7 +91,8 @@ export abstract class Control {
     let propertyBag = {};
 
     for (let prop of this.descriptor.getProperties()) {
-      propertyBag[prop.id] = prop.serializeValue(this);
+      let value = prop.serializeValue(this);
+      addValue(propertyBag, prop, value);
     }
 
     return propertyBag;

--- a/src/controls/~Button.tsx
+++ b/src/controls/~Button.tsx
@@ -60,4 +60,9 @@ export class Button extends Control {
   }
 }
 
-export let buttonDescriptor = new ReflectionBasedDescriptor('button', Button);
+export let buttonDescriptor = new ReflectionBasedDescriptor('button', 'Button', Button, () => ({
+  position: {
+    width: 100,
+    height: 30,
+  },
+}));

--- a/src/controls/~Checkbox.tsx
+++ b/src/controls/~Checkbox.tsx
@@ -75,4 +75,12 @@ export class Checkbox extends Control {
   }
 }
 
-export let checkboxDescriptor = new ReflectionBasedDescriptor('checkbox', Checkbox);
+export let checkboxDescriptor = new ReflectionBasedDescriptor('checkbox', 'Checkbox', Checkbox, () => ({
+  position: {
+    width: 150,
+    height: 30,
+  },
+  properties: {
+    [TextContentProperty.id]: 'Checkbox',
+  },
+}));

--- a/src/controls/~Label.tsx
+++ b/src/controls/~Label.tsx
@@ -44,4 +44,7 @@ export let labelDescriptor = new ReflectionBasedDescriptor('label', 'Label', Lab
     width: 200,
     height: 30,
   },
+  properties: {
+    [TextContentProperty.id]: 'A simple label',
+  },
 }));

--- a/src/controls/~Label.tsx
+++ b/src/controls/~Label.tsx
@@ -39,4 +39,9 @@ export class Label extends Control {
   }
 }
 
-export let labelDescriptor = new ReflectionBasedDescriptor('label', Label);
+export let labelDescriptor = new ReflectionBasedDescriptor('label', 'Label', Label, () => ({
+  position: {
+    width: 200,
+    height: 30,
+  },
+}));

--- a/src/controls/~RootControl.tsx
+++ b/src/controls/~RootControl.tsx
@@ -32,4 +32,4 @@ export class RootControl extends Control {
   }
 }
 
-export let rootControlDescriptor = new ReflectionBasedDescriptor('rootControl', RootControl);
+export let rootControlDescriptor = new ReflectionBasedDescriptor('rootControl', '~', RootControl);


### PR DESCRIPTION
As mentioned in issue #27, user testing showed that it was unclear that a new control was added (label specifically) because there was no default text - e.g. it was just an empty box.  This PR implements the ability for controls to specify default properties & position, and by default, if a control allows text, provides text of the form "{Control.DisplayName} {Text}".

It also gives all the controls better default width/height.

Fixes Issue #27 