### PR TITLE
Implement copy+paste support, fixing #26

### DIFF
--- a/src/control-core/controlRegistry.ts
+++ b/src/control-core/controlRegistry.ts
@@ -27,8 +27,11 @@ export interface IControlDescriptor<T extends Control = Control> {
   /** Gets the editable properties for the given element. */
   getProperties(): IControlProperty[];
 
-  /** Gets a property with the given name */
+  /** Gets a property with the given name, throwing an exception if it does not exist. */
   getProperty<T>(id: string): IControlProperty<T>;
+
+  /** Gets a property with the given name, returning null if it does not exist */
+  getPropertyOrNull<T>(id: string): IControlProperty<T> | null;
 
   /** Gets the default control properties if none are provided */
   getDefaultValues(): IDefaultControlValues;
@@ -110,12 +113,21 @@ export class ReflectionBasedDescriptor<T extends Control> implements IControlDes
   }
 
   public getProperty<T>(id: string): IControlProperty<T> {
+    let property = this.getPropertyOrNull<T>(id);
+    if (property != null) {
+      return property;
+    }
+
+    throw new Error(`Property with id ${id} does not exist`);
+  }
+
+  public getPropertyOrNull<T>(id: string): IControlProperty<T> | null {
     for (let prop of this.getProperties()) {
       if (prop.id === id) {
         return prop;
       }
     }
 
-    throw new Error(`Property with id ${id} does not exist`);
+    return null;
   }
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,6 +4,7 @@
 // learn more: https://github.com/testing-library/jest-dom
 import 'mobx-react-lite/batchingOptOut'
 import '@testing-library/jest-dom/extend-expect';
+import diff from 'jest-diff'
 
 // https://stackoverflow.com/a/52612372/548304
 const crypto = require('crypto');
@@ -13,3 +14,54 @@ Object.defineProperty(global.self, 'crypto', {
     getRandomValues: (arr: []) => crypto.randomBytes(arr.length)
   }
 });
+
+// from https://stackoverflow.com/a/45514619/548304
+expect.extend({
+  toBeWithMessage (received, expected, msg) {
+    const pass = expected === received
+    const message = pass
+      ? () => `${this.utils.matcherHint('.not.toBe')}\n\n` +
+        `Expected value to not be (using ===):\n` +
+        `  ${this.utils.printExpected(expected)}\n` +
+        `Received:\n` +
+        `  ${this.utils.printReceived(received)}`
+      : () => {
+        const diffString = diff(expected, received, {
+          expand: this.expand
+        })
+        return `${this.utils.matcherHint('.toBe')}\n\n` +
+          `Expected value to be (using ===):\n` +
+          `  ${this.utils.printExpected(expected)}\n` +
+          `Received:\n` +
+          `  ${this.utils.printReceived(received)}` +
+          `${(diffString ? `\n\nDifference:\n\n${diffString}` : '')}\n` +
+          `${(msg ? `Custom:\n  ${msg}` : '')}`
+      }
+
+    return { actual: received, message, pass }
+  },
+
+  toEqualWithMessage (received, expected, msg) {
+    const pass = this.equals(expected, received);
+    const message = pass
+      ? () => `${this.utils.matcherHint('.not.toBe')}\n\n` +
+        `Expected value to not be (using ===):\n` +
+        `  ${this.utils.printExpected(expected)}\n` +
+        `Received:\n` +
+        `  ${this.utils.printReceived(received)}`
+      : () => {
+        const diffString = diff(expected, received, {
+          expand: this.expand
+        })
+        return `${this.utils.matcherHint('.toBe')}\n\n` +
+          `Expected value to be (using ===):\n` +
+          `  ${this.utils.printExpected(expected)}\n` +
+          `Received:\n` +
+          `  ${this.utils.printReceived(received)}` +
+          `${(diffString ? `\n\nDifference:\n\n${diffString}` : '')}\n` +
+          `${(msg ? `Custom:\n  ${msg}` : '')}`
+      }
+
+    return { actual: received, message, pass }
+  }
+})

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,7 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
+import 'mobx-react-lite/batchingOptOut'
 import '@testing-library/jest-dom/extend-expect';
 
 // https://stackoverflow.com/a/52612372/548304

--- a/src/test-global.d.ts
+++ b/src/test-global.d.ts
@@ -1,0 +1,8 @@
+
+// see https://jestjs.io/docs/en/expect#expectextendmatchers
+declare namespace jest {
+  interface Matchers<R, T = {}> {
+    toBeWithMessage<E = any>(value: E, message: string): R;
+    toEqualWithMessage<E = any>(value: E, message: string): R;
+  }
+}

--- a/src/viewmodels/EditorAppViewMode.test.ts
+++ b/src/viewmodels/EditorAppViewMode.test.ts
@@ -1,0 +1,95 @@
+import { EditorAppViewModel, IApplicationHost, ICopyPasteContents } from "./EditorAppViewModel";
+import { buttonDescriptor } from "../controls/~Button";
+import { checkboxDescriptor } from "../controls/~Checkbox";
+
+let viewModel: EditorAppViewModel;
+let hostMock: IApplicationHost;
+let copiedData: ICopyPasteContents | null = null;
+
+beforeEach(() => {
+  hostMock = {
+    copyToClipboard(data: ICopyPasteContents) {
+      copiedData = data;
+    },
+    shouldAutoLoad: false
+  };
+  viewModel = new EditorAppViewModel(hostMock);
+  copiedData = null;
+})
+
+test("Adding a button adds it", () => {
+  expect(viewModel.controls.controls.length).toBe(0);
+
+  viewModel.addControl(buttonDescriptor);
+  expect(viewModel.controls.controls.length).toBe(1);
+})
+
+test("Adding a button selects it", () => {
+  viewModel.addControl(buttonDescriptor);
+  expect(viewModel.controls.primarySelected).not.toBeNull();
+})
+
+test("Adding can be undone", () => {
+  viewModel.addControl(buttonDescriptor);
+  expect(viewModel.controls.controls.length).toBe(1);
+  expect(viewModel.undoRedo.canUndo).toBeTruthy();
+  expect(viewModel.undoRedo.canRedo).toBeFalsy();
+
+  viewModel.undo();
+  expect(viewModel.controls.controls.length).toBe(0);
+  expect(viewModel.undoRedo.canUndo).toBeFalsy();
+  expect(viewModel.undoRedo.canRedo).toBeTruthy();
+})
+
+test("Adding can be undone & redone", () => {
+  viewModel.addControl(buttonDescriptor);
+  expect(viewModel.controls.controls.length).toBe(1);
+
+  viewModel.undo();
+  expect(viewModel.controls.controls.length).toBe(0);
+
+  viewModel.redo();
+  expect(viewModel.controls.controls.length).toBe(1);
+  expect(viewModel.undoRedo.canUndo).toBeTruthy();
+  expect(viewModel.undoRedo.canRedo).toBeFalsy();
+})
+
+test("Copy works", () => {
+  viewModel.addControl(buttonDescriptor);
+  viewModel.addControl(checkboxDescriptor);
+  expect(viewModel.controls.controls.length).toBe(2);
+  expect(viewModel.controls.primarySelected?.typeId).toBe(checkboxDescriptor.id);
+
+  viewModel.copySelected();
+  expect(copiedData).not.toBe(null);
+  expect(copiedData?.text).not.toBeNull();
+  expect(copiedData?.text).not.toEqual("");
+  expect(copiedData?.data).not.toBeNull();
+  expect(copiedData?.data).not.toEqual("");
+})
+
+test("Copy does nothing if nothing is selected", () => {
+  viewModel.addControl(buttonDescriptor);
+  viewModel.addControl(checkboxDescriptor);
+  expect(viewModel.controls.controls.length).toBe(2);
+  viewModel.controls.primarySelected!.isSelected = false;
+
+  viewModel.copySelected();
+  expect(copiedData).toBe(null);
+})
+
+test("Copy & paste works", () => {
+  viewModel.addControl(buttonDescriptor);
+  viewModel.addControl(checkboxDescriptor);
+  expect(viewModel.controls.controls.length).toBe(2);
+  expect(viewModel.controls.primarySelected?.typeId).toBe(checkboxDescriptor.id);
+
+  let previousIds = new Set(viewModel.controls.controls.map(c => c.id));
+  viewModel.copySelected();
+  expect(copiedData).not.toBe(null);
+
+  viewModel.paste(copiedData!);
+  expect(viewModel.controls.controls.length).toBe(3);
+  let newControl = viewModel.controls.primarySelected!;
+  expect(previousIds.has(newControl.id)).toBe(false)
+})

--- a/src/viewmodels/EditorAppViewModel.ts
+++ b/src/viewmodels/EditorAppViewModel.ts
@@ -6,15 +6,41 @@ import { ControlInformationViewModel } from './ControlInformationViewModel';
 import { generateUniqueId } from '../util/UniqueId';
 import { action } from 'mobx';
 import { SelectedControlInformation } from './EditableControlPropertiesViewModel';
+import { TextContentProperty } from "../control-core/~TextContentProperty";
 
 const AutoSaveLayoutName = '$autosave$';
 
+/**
+ * Data exchange format when interacting with the clipboard.
+ */
+export interface ICopyPasteContents {
+  /** The text representation of the data **/
+  text: string;
+  /** The serialied json representation of the data **/
+  data?: string;
+}
+
+/**
+ * The methods required for any host that wants to run the EditorAppViewModel
+ */
+export interface IApplicationHost {
+  /**
+   * Copy the given data into the clipboard
+   * @param data the data to copy
+   */
+  copyToClipboard(data: ICopyPasteContents): void;
+}
+
 export class EditorAppViewModel {
+  private _host: IApplicationHost;
+
   public readonly controls: ControlCollectionViewModel;
   public readonly undoRedo: UndoRedoQueueViewModel;
   public readonly selectedInformation: SelectedControlInformation;
 
-  constructor() {
+  constructor(host: IApplicationHost) {
+    this._host = host;
+
     this.controls = new ControlCollectionViewModel();
     this.undoRedo = new UndoRedoQueueViewModel(this);
     this.selectedInformation = new SelectedControlInformation(this.controls, this.undoRedo);
@@ -70,7 +96,6 @@ export class EditorAppViewModel {
   public addControl(descriptor: IControlDescriptor) {
     let normalizedDefaults = EditorAppViewModel.createInitialValues(descriptor);
 
-    // TODO copy the data
     let data: IControlSerializedData = {
       id: generateUniqueId(),
       typeId: descriptor.id,
@@ -107,6 +132,58 @@ export class EditorAppViewModel {
         })),
       });
     }
+  }
+
+  /**
+   *  Copies teh currently selected control to the clipboard
+   */
+  public async copySelected() {
+
+    let selected = this.controls.primarySelected;
+    if (selected == null) {
+      return;
+    }
+
+    let serialized = selected.serialize();
+    let asJson = JSON.stringify(serialized);
+
+    let descriptionText: string;
+    let property = selected.control.descriptor.getPropertyOrNull<string>(TextContentProperty.id);
+    if (property != null) {
+      let text = property.getValue(selected.control);
+      descriptionText = `${selected.control.descriptor.id}: ${text}`;
+    } else {
+      descriptionText = `${selected.control.descriptor.id}`;
+    }
+
+    this._host.copyToClipboard({
+      text: descriptionText,
+      data: asJson,
+    });
+  }
+
+  /**
+   *  Pastes the clipboard onto the canvas
+   */
+  public paste(contents: ICopyPasteContents) {
+    if (contents.data == null) {
+      return;
+    }
+
+    let data = JSON.parse(contents.data) as IControlSerializedData;
+
+    let descriptor = this.controls.findDescriptor(data.typeId);
+    data.id = generateUniqueId();
+
+    this.undoRedo.add(addControlsUndoHandler, {
+      controlsVm: this.controls,
+      entries: [
+        {
+          descriptor: descriptor,
+          data: data,
+        },
+      ],
+    });
   }
 
   /**

--- a/src/viewmodels/EditorAppViewModel.ts
+++ b/src/viewmodels/EditorAppViewModel.ts
@@ -29,6 +29,11 @@ export interface IApplicationHost {
    * @param data the data to copy
    */
   copyToClipboard(data: ICopyPasteContents): void;
+
+  /**
+   * True if the app should automatically save & load the layout on startup/shutdown
+   */
+  shouldAutoLoad: boolean;
 }
 
 export class EditorAppViewModel {
@@ -45,12 +50,16 @@ export class EditorAppViewModel {
     this.undoRedo = new UndoRedoQueueViewModel(this);
     this.selectedInformation = new SelectedControlInformation(this.controls, this.undoRedo);
 
-    this.loadLayout(AutoSaveLayoutName);
+    if (this._host.shouldAutoLoad) {
+      this.loadLayout(AutoSaveLayoutName);
+    }
   }
 
   @action
   public shutdown() {
-    this.saveLayout(AutoSaveLayoutName);
+    if (this._host.shouldAutoLoad) {
+      this.saveLayout(AutoSaveLayoutName);
+    }
   }
 
   @action

--- a/src/views/EditorApp.tsx
+++ b/src/views/EditorApp.tsx
@@ -12,6 +12,10 @@ let browserHost = new (class implements IApplicationHost {
   private mimeTypeEngine = "engine/paste+data";
   private mimeTypePlain = "text/plain";
 
+  public get shouldAutoLoad() {
+    return true;
+  }
+
   public copyToClipboard(contents: ICopyPasteContents): void {
     // https://gist.github.com/lgarron/d1dee380f4ed9d825ca7
     let listener = (e: ClipboardEvent) => {
@@ -40,7 +44,7 @@ let browserHost = new (class implements IApplicationHost {
     let text = e.clipboardData.getData(this.mimeTypePlain);
     let data: string | null = e.clipboardData.getData(this.mimeTypeEngine);
 
-    if (data == "") {
+    if (data === "") {
       return {
         text
       };
@@ -51,7 +55,7 @@ let browserHost = new (class implements IApplicationHost {
       };
     }
   }
-});
+})();
 
 
 let editorVm = new EditorAppViewModel(browserHost);

--- a/src/views/EditorApp.tsx
+++ b/src/views/EditorApp.tsx
@@ -1,14 +1,70 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import './App.css';
 import { DesignCanvas } from './DesignCanvas';
 import { observer } from 'mobx-react';
-import { EditorAppViewModel } from '../viewmodels/EditorAppViewModel';
+import { EditorAppViewModel, IApplicationHost, ICopyPasteContents } from '../viewmodels/EditorAppViewModel';
 import { PropertiesPanel } from './PropertiesPanel';
 import hotkeys from 'hotkeys-js';
 
-let editorVm = new EditorAppViewModel();
+
+let browserHost = new (class implements IApplicationHost {
+
+  private mimeTypeEngine = "engine/paste+data";
+  private mimeTypePlain = "text/plain";
+
+  public copyToClipboard(contents: ICopyPasteContents): void {
+    // https://gist.github.com/lgarron/d1dee380f4ed9d825ca7
+    let listener = (e: ClipboardEvent) => {
+      e.clipboardData!.setData(this.mimeTypePlain, contents.text);
+
+      if (contents.data != null) {
+        e.clipboardData!.setData(this.mimeTypeEngine, contents.data);
+      }
+
+      e.preventDefault();
+    };
+
+    try {
+      document.addEventListener("copy", listener);
+      document.execCommand("copy");
+    } finally {
+      document.removeEventListener("copy", listener);
+    }
+  }
+
+  public retrieveData(e: ClipboardEvent): ICopyPasteContents | null {
+    if (e.clipboardData == null) {
+      return null;
+    }
+
+    let text = e.clipboardData.getData(this.mimeTypePlain);
+    let data: string | null = e.clipboardData.getData(this.mimeTypeEngine);
+
+    if (data == "") {
+      return {
+        text
+      };
+    } else {
+      return {
+        text,
+        data
+      };
+    }
+  }
+});
+
+
+let editorVm = new EditorAppViewModel(browserHost);
 
 let EditorApp = observer(function EditorApp() {
+
+  let pasteCallback = useCallback((event: ClipboardEvent) => {
+    let data = browserHost.retrieveData(event);
+    if (data != null) {
+      editorVm.paste(data);
+    }
+  }, []);
+
   useEffect(() => {
     const scopeName = 'app';
 
@@ -21,10 +77,13 @@ let EditorApp = observer(function EditorApp() {
 
     add('ctrl+z', () => editorVm.undo());
     add('ctrl+y', () => editorVm.redo());
+    add('ctrl+c', () => editorVm.copySelected());
     add('delete', () => editorVm.removeSelected());
     add('ctrl+n', () => editorVm.clearLayout());
 
     hotkeys.setScope(scopeName);
+
+    (window as any).addEventListener("paste", pasteCallback);
 
     window.addEventListener("unload", () => {
       editorVm.shutdown();
@@ -32,8 +91,9 @@ let EditorApp = observer(function EditorApp() {
 
     return () => {
       hotkeys.deleteScope(scopeName);
+      (window as any).removeEventListener("paste", pasteCallback);
     };
-  }, []);
+  }, [pasteCallback]);
 
   return (
     <div className="design-app">
@@ -46,6 +106,7 @@ let EditorApp = observer(function EditorApp() {
           </button>
         ))}
         <button onClick={() => editorVm.removeSelected()}>Delete</button>
+        <button onClick={() => editorVm.copySelected()}>Copy</button>
         <button onClick={() => editorVm.undo()}>Undo</button>
         <button onClick={() => editorVm.redo()}>Redo</button>
         <button onClick={() => editorVm.saveLayout('manual')}>Save Layout</button>


### PR DESCRIPTION
Per issue #26, implement copy+paste.

Copy is implemented by exec'ing the command; pasting is done by hooking into the native "paste" handler, as this is the only way to implement non-visible pasting is to hook into.

Firefox read clipboard is currently unsupported without flipping a flag (see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#Browser_compatibility); we may revisit this in the future.